### PR TITLE
working and refactored

### DIFF
--- a/.bazelproject
+++ b/.bazelproject
@@ -4,13 +4,13 @@ directories:
   build_defs
   tools
   third_party
-  particles
+#  particles
   src
 
 targets:
   //java/...
   //javatests/...
-  //particles/...
+#  //particles/...
 
 test_sources:
   javatests/

--- a/java/arcs/android/storage/BUILD
+++ b/java/arcs/android/storage/BUILD
@@ -41,6 +41,21 @@ android_proto_library(
 )
 
 proto_library(
+    name = "remote_message_proto",
+    srcs = ["remote_message.proto"],
+    deps = [
+        ":proxy_message_proto",
+        ":store_options_proto",
+        "//third_party/java/arcs/deps:protobuf_wrappers_proto",
+    ],
+)
+
+android_proto_library(
+    name = "remote_message_android_proto",
+    deps = [":remote_message_proto"],
+)
+
+proto_library(
     name = "store_options_proto",
     srcs = ["store_options.proto"],
     deps = [

--- a/java/arcs/android/storage/remote_message.proto
+++ b/java/arcs/android/storage/remote_message.proto
@@ -1,0 +1,33 @@
+syntax = "proto3";
+
+package arcs.android.storage;
+
+import "java/arcs/android/storage/proxy_message.proto";
+import "java/arcs/android/storage/store_options.proto";
+
+option java_package = "arcs.android.storage";
+option java_multiple_files = true;
+
+message RemoteMessageProto {
+  int32 message_id = 1;
+  int32 channel_id = 2;
+  oneof message {
+    ConnectMessageProto connect_message = 3;
+    ProxyMessageProto proxy_message = 4;
+    IdleMessageProto idle_message = 5;
+    AckMessageProto ack_message = 6;
+    CloseMessageProto close_message = 7;
+  }
+
+  message ConnectMessageProto {
+    StoreOptionsProto store_options = 8;
+  }
+
+  message IdleMessageProto {}
+
+  message AckMessageProto {
+    int32 message_id = 9;
+  }
+
+  message CloseMessageProto {}
+}

--- a/java/arcs/core/host/ArcHostContextParticle.kt
+++ b/java/arcs/core/host/ArcHostContextParticle.kt
@@ -174,11 +174,25 @@ class ArcHostContextParticle(
     val onReadyJobs = mapOf(
       "particles" to Job(),
       "arcHostContext" to Job(),
-      "handleConnections" to Job()
+      "handleConnections" to Job(),
+      "planHandles" to Job()
     )
-    handles.particles.onReady { onReadyJobs["particles"]?.complete() }
-    handles.arcHostContext.onReady { onReadyJobs["arcHostContext"]?.complete() }
-    handles.handleConnections.onReady { onReadyJobs["handleConnections"]?.complete() }
+    handles.particles.onReady {
+      println("particles rdy")
+      onReadyJobs["particles"]?.complete()
+    }
+    handles.arcHostContext.onReady {
+      println("archost rdy")
+      onReadyJobs["arcHostContext"]?.complete()
+    }
+    handles.handleConnections.onReady {
+      println("handleConnections ready")
+      onReadyJobs["handleConnections"]?.complete()
+    }
+    handles.planHandles.onReady {
+      println("planHandles rdy")
+      onReadyJobs["planHandles"]?.complete()
+    }
     onReadyJobs.values.joinAll()
     return withContext(coroutineContext) { block() }.also { handleManager.close() }
   }

--- a/java/arcs/core/util/Log.kt
+++ b/java/arcs/core/util/Log.kt
@@ -93,7 +93,7 @@ object Log {
   }
 }
 
-private val DEFAULT_LEVEL = Log.Level.Error
+private val DEFAULT_LEVEL = Log.Level.Debug
 
 private val DEFAULT_FORMATTER: (
   index: Int,

--- a/java/arcs/sdk/android/storage/BUILD
+++ b/java/arcs/sdk/android/storage/BUILD
@@ -13,6 +13,7 @@ arcs_kt_android_library(
         "//java/arcs/android/crdt",
         "//java/arcs/android/storage",
         "//java/arcs/android/storage:proxy_message_android_proto",
+        "//java/arcs/android/storage:remote_message_android_proto",
         "//java/arcs/android/storage/database",
         "//java/arcs/android/storage/service",
         "//java/arcs/android/storage/service:aidl",

--- a/java/arcs/sdk/android/storage/ProtoChannel.kt
+++ b/java/arcs/sdk/android/storage/ProtoChannel.kt
@@ -1,0 +1,132 @@
+package arcs.sdk.android.storage
+
+import arcs.android.storage.RemoteMessage
+import arcs.android.storage.RemoteMessageProto
+import arcs.android.storage.decode
+import arcs.android.storage.toProto
+import arcs.android.util.decodeProto
+import arcs.core.crdt.CrdtData
+import arcs.core.crdt.CrdtOperationAtTime
+import arcs.core.storage.ProxyCallback
+import arcs.core.storage.ProxyMessage
+import arcs.core.storage.StoreOptions
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.BroadcastChannel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+
+class ProtoChannel<Data : CrdtData, Op : CrdtOperationAtTime, T>(
+  val sendChannel: Channel<ByteArray>,
+  val recvChannel: BroadcastChannel<ByteArray>,
+  val channelId: Int,
+  val msgIdProvider: () -> Int
+) {
+  var nextMessageId = 1
+  fun newEnvelope() =
+    RemoteMessageProto.newBuilder().setMessageId(msgIdProvider()).setChannelId(channelId)
+
+  fun newClose() =
+    newEnvelope().setCloseMessage(RemoteMessageProto.CloseMessageProto.getDefaultInstance()).build()
+
+  fun newIdle() =
+    newEnvelope().setIdleMessage(RemoteMessageProto.IdleMessageProto.getDefaultInstance()).build()
+
+  fun newConnect(storeOptions: StoreOptions) =
+    newEnvelope().setConnectMessage(
+      RemoteMessageProto.ConnectMessageProto.newBuilder().setStoreOptions(storeOptions.toProto()).build()
+    ).build()
+
+  fun newProxyMessage(message: ProxyMessage<Data, Op, T>) =
+    newEnvelope().setProxyMessage(message.toProto()).build()
+
+  suspend fun sendClose() {
+    val closeMsg = newClose()
+    sendChannel.send(closeMsg.toByteArray())
+//    recvChannel.waitForAck(channelId, closeMsg.messageId)
+  }
+
+  suspend fun sendIdle() {
+    val idleMsg = newIdle()
+    sendChannel.send(idleMsg.toByteArray())
+    recvChannel.waitForAck(channelId, idleMsg.messageId)
+  }
+
+  suspend fun sendConnect(storeOptions: StoreOptions) {
+    val connectMsg = newConnect(storeOptions)
+    sendChannel.send(connectMsg.toByteArray())
+    recvChannel.waitForAck(channelId, connectMsg.messageId)
+  }
+
+  suspend fun sendProxyMessage(message: ProxyMessage<Data, Op, T>) {
+    val proxyMessage = newProxyMessage(message)
+    sendChannel.send(proxyMessage.toByteArray())
+    recvChannel.waitForAck(channelId, proxyMessage.messageId)
+  }
+
+  suspend fun sendProxyMessageToClient(channelId: Int, message: ProxyMessage<Data, Op, T>) {
+    val proxyMessage = RemoteMessageProto.newBuilder()
+      .setChannelId(channelId)
+      .setMessageId(msgIdProvider())
+      .setProxyMessage(message.toProto())
+      .build()
+    recvChannel.send(proxyMessage.toByteArray())
+  }
+
+  suspend fun sendAck(channelId: Int, msgId: Int) {
+    val ackMsg = RemoteMessageProto.newBuilder()
+      .setChannelId(channelId)
+      .setMessageId(msgId)
+      .setAckMessage(
+        RemoteMessageProto.AckMessageProto.newBuilder().setMessageId(msgId).build()
+      ).build()
+    println("Sending ack froms server for channelId = ${ackMsg.channelId}, id=${ackMsg.messageId}")
+    recvChannel.send(ackMsg.toByteArray())
+  }
+
+  fun startClient(
+    callback: ProxyCallback<Data, Op, T>,
+    scope: CoroutineScope
+  ) {
+    recvChannel.openSubscription().consumeAsFlow().map { message ->
+      decodeProto(message, RemoteMessageProto.getDefaultInstance())
+    }.filter {
+      it.channelId == channelId
+    }.filter {
+      it.hasProxyMessage()
+    }.map {
+      it.proxyMessage.decode()
+    }.onEach {
+      println("Received $it proxy message invoking callback for channel id $channelId")
+      callback(it as ProxyMessage<Data, Op, T>)
+    }.launchIn(scope)
+  }
+
+  fun startServer(
+    scope: CoroutineScope,
+    callback: suspend (RemoteMessageProto) -> Unit
+  ) {
+    sendChannel.consumeAsFlow().map { message ->
+      decodeProto(message, RemoteMessageProto.getDefaultInstance())
+    }.onEach { callback(it) }.launchIn(scope)
+  }
+
+  suspend fun close() {
+
+  }
+
+  private suspend fun BroadcastChannel<ByteArray>.waitForAck(channelId: Int, id: Int) {
+    println("Waiting for Ack channel=$channelId, id=$id")
+    this.openSubscription().consumeAsFlow().map { message ->
+      decodeProto(message, RemoteMessageProto.getDefaultInstance())
+    }.filter { it.hasAckMessage() && it.channelId == channelId }
+      .first { it.messageId == id }
+    println("Ack received channel=$channelId, id=$id")
+  }
+}
+
+

--- a/java/arcs/sdk/android/storage/RemoteServerStorageEndpointManager.kt
+++ b/java/arcs/sdk/android/storage/RemoteServerStorageEndpointManager.kt
@@ -1,0 +1,86 @@
+package arcs.sdk.android.storage
+
+import arcs.android.storage.decode
+import arcs.core.common.CounterFlow
+import arcs.core.crdt.CrdtData
+import arcs.core.crdt.CrdtOperation
+import arcs.core.crdt.CrdtOperationAtTime
+import arcs.core.storage.ActiveStore
+import arcs.core.storage.DirectStorageEndpointManager
+import arcs.core.storage.ProxyCallback
+import arcs.core.storage.ProxyMessage
+import arcs.core.storage.StorageEndpoint
+import arcs.core.storage.StorageEndpointManager
+import arcs.core.storage.StorageKey
+import arcs.core.storage.StoreManager
+import arcs.core.storage.StoreOptions
+import arcs.core.storage.StoreWriteBack
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.BroadcastChannel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.first
+
+/**
+ * A [StorageEndpointManager] that creates communciates with another [StorageEndpoint] via
+ * byte-encoded Protobufs over a set of [Channel]s.
+ */
+class RemoteStorageEndpointManagerServer<Data : CrdtData, Op : CrdtOperationAtTime, T>(
+  private val sendChannel: Channel<ByteArray>,
+  private val recvChannel: BroadcastChannel<ByteArray>,
+  private val endpointManager: StorageEndpointManager,
+  private val scope: CoroutineScope
+  ) {
+  val protoChannel = ProtoChannel<Data, Op, T>(sendChannel, recvChannel, 1, msgIdProvider = { 1 })
+  var remoteEndpoints: MutableMap<Int, StorageEndpoint<Data, Op, T>?> = mutableMapOf()
+  var remoteEndpointClients: MutableMap<StorageKey, MutableSet<Int>> = mutableMapOf()
+  var remoteClientToKey: MutableMap<Int, StorageKey> = mutableMapOf()
+
+  fun start() {
+    protoChannel.startServer(scope) { message ->
+      when {
+        message.hasConnectMessage() -> {
+          val channelId = message.channelId
+          val storeOptions = message.connectMessage.storeOptions.decode()
+          remoteClientToKey.put(channelId, storeOptions.storageKey)
+          val clients = remoteEndpointClients.getOrPut(storeOptions.storageKey) {
+            mutableSetOf<Int>()
+          }
+          clients.add(channelId)
+          remoteEndpoints.getOrPut(channelId) {
+            val endpoint = endpointManager.get<Data, Op, T>(
+              storeOptions
+            ) { proxyMessage ->
+              remoteEndpointClients.get(storeOptions.storageKey)?.forEach { clientId ->
+                println("Sending proxy message to client $clientId, $proxyMessage")
+                protoChannel.sendProxyMessageToClient(clientId, proxyMessage)
+              }
+            }
+            protoChannel.sendAck(channelId, message.messageId)
+            endpoint
+          }
+        }
+        message.hasIdleMessage() -> {
+          remoteEndpoints.get(message.channelId)?.idle()
+          protoChannel.sendAck(message.channelId, message.messageId)
+        }
+        message.hasCloseMessage() -> {
+          println("calling close channelId=${message.channelId} id=${message.messageId}")
+          val clients = remoteEndpointClients.get(remoteClientToKey.get(message.channelId))
+          clients?.remove(message.channelId)
+          if (clients?.isEmpty() ?: false) {
+            println("closing endpoint")
+            remoteEndpoints.get(message.channelId)?.close() ?: println("missing endpoint close")
+          }
+          protoChannel.sendAck(message.channelId, message.messageId)
+        }
+        message.hasProxyMessage() -> {
+          remoteEndpoints.get(message.channelId)?.onProxyMessage(
+            message.proxyMessage.decode() as ProxyMessage<Data, Op, T>
+          )
+          protoChannel.sendAck(message.channelId, message.messageId)
+        }
+      }
+    }
+  }
+}
+

--- a/java/arcs/sdk/android/storage/RemoteStorageEndpointManager.kt
+++ b/java/arcs/sdk/android/storage/RemoteStorageEndpointManager.kt
@@ -1,0 +1,114 @@
+package arcs.sdk.android.storage
+
+import arcs.android.storage.RemoteMessageProto
+import arcs.android.util.decodeProto
+import arcs.core.common.CounterFlow
+import arcs.core.crdt.CrdtData
+import arcs.core.crdt.CrdtOperationAtTime
+import arcs.core.storage.ActiveStore
+import arcs.core.storage.ProxyCallback
+import arcs.core.storage.ProxyMessage
+import arcs.core.storage.StorageEndpoint
+import arcs.core.storage.StorageEndpointManager
+import arcs.core.storage.StorageKey
+import arcs.core.storage.StoreOptions
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.BroadcastChannel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+/**
+ * A [StorageEndpointManager] that creates [DirectStorageEndpointProviders] wrapping the stores
+ * provided in the [stores] parameter.
+ */
+class RemoteStorageEndpointManager(
+  private val sendChannel: Channel<ByteArray>,
+  private val recvChannel: BroadcastChannel<ByteArray>,
+  private val scope: CoroutineScope
+  ) : StorageEndpointManager {
+
+  var nextMsgId = atomic(1)
+  var nextChannelId = atomic(1)
+
+  val msgIdProvider = { nextMsgId.incrementAndGet() }
+  val channelIdProvider = { nextChannelId.incrementAndGet() }
+
+  val stores: MutableMap<StorageKey, RemoteStorageEndpoint<*, *, *>> = mutableMapOf()
+
+  override suspend fun <Data : CrdtData, Op : CrdtOperationAtTime, T> get(
+    storeOptions: StoreOptions,
+    callback: ProxyCallback<Data, Op, T>
+  ): StorageEndpoint<Data, Op, T> {
+    return stores.getOrPut(storeOptions.storageKey) {
+      val channelId = channelIdProvider()
+      val protoChannel = ProtoChannel<Data, Op, T>(sendChannel, recvChannel, channelId, msgIdProvider)
+      protoChannel.sendConnect(storeOptions)
+
+      return Unit.let {
+        RemoteStorageEndpoint<Data, Op, T>(
+          sendChannel,
+          recvChannel,
+          msgIdProvider,
+          channelId,
+          protoChannel
+        )
+      }.also {
+        protoChannel.startClient(callback, scope)
+      }
+    } as RemoteStorageEndpoint<Data, Op, T>
+  }
+}
+
+private suspend fun BroadcastChannel<ByteArray>.waitForAck(channelId: Int, id: Int) =
+  this.openSubscription().consumeAsFlow().map { message ->
+    decodeProto(message, RemoteMessageProto.getDefaultInstance())
+  }.filter {
+    it.hasAckMessage() && it.channelId == channelId
+  }.map {
+    println(it.ackMessage)
+    it.ackMessage
+  }.first { it.messageId == id }
+
+/** A [StorageEndpoint] that directly wraps an [ActiveStore]. */
+class RemoteStorageEndpoint<Data : CrdtData, Op : CrdtOperationAtTime, T>(
+  private val sendChannel: Channel<ByteArray>,
+  private val recvChannel: BroadcastChannel<ByteArray>,
+  private val msgIdProvider: () -> Int,
+  private val channelId: Int,
+  private val protoChannel: ProtoChannel<Data, Op, T>
+) : StorageEndpoint<Data, Op, T> {
+  private val outgoingMessagesCount = CounterFlow(0)
+
+  override suspend fun idle() {
+    outgoingMessagesCount.flow.first { it == 0 }
+    protoChannel.sendIdle()
+  }
+
+  override suspend fun onProxyMessage(
+    message: ProxyMessage<Data, Op, T>
+  ) {
+    outgoingMessagesCount.increment()
+    try {
+      protoChannel.sendProxyMessage(message)
+    } finally {
+      outgoingMessagesCount.decrement()
+    }
+  }
+
+  override suspend fun close() {
+//    protoChannel.sendClose()
+    println("Close called2")
+    val msgId = msgIdProvider()
+    sendChannel.send(
+      RemoteMessageProto.newBuilder().setMessageId(
+        msgId
+      ).setChannelId(channelId).setCloseMessage(RemoteMessageProto.CloseMessageProto.getDefaultInstance()).build().toByteArray()
+    )
+    // send close message
+    recvChannel.waitForAck(channelId, msgId)
+  }
+}

--- a/javatests/arcs/showcase/BUILD
+++ b/javatests/arcs/showcase/BUILD
@@ -10,7 +10,7 @@ package(default_visibility = ["//java/arcs:allowed-packages"])
 arcs_kt_android_library(
     name = "showcase",
     testonly = 1,
-    srcs = ["ShowcaseEnvironment.kt"],
+    srcs = ["ShowcaseEnvironment.kt", "ShowcaseEnvironmentRemoteStorage.kt"],
     deps = [
         "//java/arcs/android/sdk/host",
         "//java/arcs/android/storage/database",

--- a/javatests/arcs/showcase/ShowcaseEnvironmentRemoteStorage.kt
+++ b/javatests/arcs/showcase/ShowcaseEnvironmentRemoteStorage.kt
@@ -1,0 +1,241 @@
+@file:Suppress("EXPERIMENTAL_IS_NOT_ENABLED")
+
+package arcs.showcase
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.testing.WorkManagerTestInitHelper
+import arcs.android.storage.database.AndroidSqliteDatabaseManager
+import arcs.core.allocator.Allocator
+import arcs.core.allocator.Arc
+import arcs.core.crdt.CrdtData
+import arcs.core.crdt.CrdtOperationAtTime
+import arcs.core.data.Plan
+import arcs.core.host.AbstractArcHost
+import arcs.core.host.ArcHost
+import arcs.core.host.ParticleRegistration
+import arcs.core.host.ParticleState
+import arcs.core.host.SchedulerProvider
+import arcs.core.storage.DirectStorageEndpointManager
+import arcs.core.storage.StorageEndpointManager
+import arcs.core.storage.StoreManager
+import arcs.core.storage.StoreWriteBack
+import arcs.core.storage.api.DriverAndKeyConfigurator
+import arcs.core.storage.driver.RamDisk
+import arcs.core.util.TaggedLog
+import arcs.jvm.host.ExplicitHostRegistry
+import arcs.jvm.host.JvmSchedulerProvider
+import arcs.jvm.util.JvmTime
+import arcs.sdk.Particle
+import arcs.sdk.android.storage.RemoteStorageEndpointManager
+import arcs.sdk.android.storage.RemoteStorageEndpointManagerServer
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.BroadcastChannel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+/**
+ * A JUnit rule setting up an Arcs environment for showcasing features.
+ *
+ * Usage example follows:
+ *
+ * ```
+ * @get:Rule val env = ShowcaseEnvironment(
+ *     ::SomeParticle.toRegistration(),
+ *     ::OtherParticle.toRegistration(),
+ * )
+ *
+ * @Test
+ * fun answerToEverythingIsCorrect() = runTest {
+ *   // Start an Arc.
+ *   val arc = env.startArc(YourGeneratedPlan)
+ *
+ *   // Do something with it.
+ *   env.getParticle<SomeParticle>(arc).query("what's the answer?")
+ *
+ *   // Assert result.
+ *   assertThat(env.getParticle<OtherParticle>(arc).state).isEqualTo(42)
+ * }
+ * ```
+ */
+@ExperimentalCoroutinesApi
+class ShowcaseEnvironmentRemoteStorage(
+  private val lifecycleTimeoutMillis: Long = 60000,
+  vararg val particleRegistrations: ParticleRegistration
+) : TestRule {
+  private val log = TaggedLog { "ShowcaseEnvironment" }
+
+  lateinit var allocator: Allocator
+  lateinit var arcHost: ShowcaseHost
+
+  private val startedArcs = mutableListOf<Arc>()
+
+  constructor(vararg particleRegistrations: ParticleRegistration) :
+    this(60000, *particleRegistrations)
+
+  /**
+   * Starts an [Arc] for a given [Plan] and waits for it to be ready.
+   */
+  suspend fun startArc(plan: Plan): Arc {
+    log.info { "Starting arc for plan: $plan" }
+    val arc = allocator.startArcForPlan(plan)
+    startedArcs.add(arc)
+    log.info { "Waiting for start of $arc" }
+    arc.waitForStart()
+    log.info { "Arc started: $arc" }
+    return arc
+  }
+
+  /**
+   * Retrieves a [Particle] instance from a given [Arc].
+   */
+  suspend inline fun <reified T : Particle> getParticle(plan: Plan): T {
+    require(plan.arcId != null) {
+      "retrieving a particle for non-singleton plans is not supported"
+    }
+    val arc = startArc(plan)
+    return arcHost.getParticle(arc.id.toString(), T::class.simpleName!!)
+  }
+
+  /**
+   * Retrieves a [Particle] instance from a given [Arc].
+   */
+  suspend inline fun <reified T : Particle> getParticle(arc: Arc): T {
+    return arcHost.getParticle(arc.id.toString(), T::class.simpleName!!)
+  }
+
+  /**
+   * Stops a given [Arc].
+   */
+  suspend fun stopArc(arc: Arc) = allocator.stopArc(arc.id)
+
+  override fun apply(statement: Statement, description: Description): Statement {
+    val suspendingStatement = object : SuspendingStatement {
+      override suspend fun evaluate() {
+        val components = startupArcs()
+        try {
+          // Running the test within a try block, so we can clean up in the finally
+          // section, even if the test fails.
+          statement.evaluate()
+        } finally {
+          teardownArcs(components)
+        }
+      }
+    }
+
+    return TimeLimitedStatement(suspendingStatement, description, lifecycleTimeoutMillis)
+  }
+
+  private interface SuspendingStatement {
+    suspend fun evaluate()
+  }
+
+  private class TimeLimitedStatement(
+    private val innerStatement: SuspendingStatement,
+    @Suppress("unused") private val description: Description,
+    private val timeoutMillis: Long
+  ) : Statement() {
+    override fun evaluate() = runBlocking {
+      withTimeout(timeoutMillis) { innerStatement.evaluate() }
+    }
+  }
+
+  private suspend fun startupArcs(): ShowcaseArcsComponents {
+    // Reset the RamDisk.
+    RamDisk.clear()
+
+    // Initializing the environment...
+    val context = ApplicationProvider.getApplicationContext<Application>()
+    WorkManagerTestInitHelper.initializeTestWorkManager(context)
+
+    // Set up the Database manager, drivers, and keys/key-parsers.
+    val dbManager = AndroidSqliteDatabaseManager(context).also {
+      // Be sure we always start with a fresh, empty database.
+      it.resetAll()
+    }
+
+    DriverAndKeyConfigurator.configure(dbManager)
+
+    // Create a child job so we can cancel it to shut down the endpoint manager,
+    // without breaking the test.
+    val job = Job(coroutineContext[Job.Key])
+    val scope = CoroutineScope(coroutineContext + job)
+
+    val schedulerProvider = JvmSchedulerProvider(Dispatchers.Default)
+
+    // Create our ArcHost, capturing the StoreManager so we can manually wait for idle
+    // on it once the test is done.
+    val actualStorageEndpointManager = DirectStorageEndpointManager(
+      StoreManager(scope) { protocol ->
+        StoreWriteBack(
+          protocol,
+          Channel.UNLIMITED,
+          forceEnable = true,
+          scope = scope
+        )
+      }
+    )
+    val sendChannel = Channel<ByteArray>(1000)
+    val recvChannel = BroadcastChannel<ByteArray>(1000)
+
+    val storageEndpointManager = RemoteStorageEndpointManager(
+      sendChannel,
+      recvChannel,
+      scope
+    )
+
+    val remoteStorageServer = RemoteStorageEndpointManagerServer<CrdtData, CrdtOperationAtTime, Any?>(
+      sendChannel,
+      recvChannel,
+      actualStorageEndpointManager,
+      scope
+    )
+
+    remoteStorageServer.start()
+
+    arcHost = ShowcaseHost(
+      Dispatchers.Default,
+      schedulerProvider,
+      storageEndpointManager,
+      *particleRegistrations
+    )
+
+    // Create our allocator, and no need to have it support arc serialization for the
+    // showcase.
+    allocator = Allocator.createNonSerializing(
+      ExplicitHostRegistry().apply {
+        registerHost(arcHost)
+      }
+    )
+
+    return ShowcaseArcsComponents(scope, dbManager, storageEndpointManager, arcHost)
+  }
+
+  private suspend fun teardownArcs(components: ShowcaseArcsComponents) {
+    // Stop all the arcs and shut down the arcHost.
+    startedArcs.forEach { it.stop() }
+    components.arcHost.shutdown()
+
+    // Reset the Databases and close them.
+    components.dbManager.resetAll()
+    components.dbManager.close()
+    components.scope.cancel()
+  }
+
+  private data class ShowcaseArcsComponents(
+    val scope: CoroutineScope,
+    val dbManager: AndroidSqliteDatabaseManager,
+    val arcStorageEndpointManager: StorageEndpointManager,
+    val arcHost: ArcHost
+  )
+}

--- a/javatests/arcs/showcase/expression/ExpressionShowcaseTest.kt
+++ b/javatests/arcs/showcase/expression/ExpressionShowcaseTest.kt
@@ -17,6 +17,7 @@ import arcs.core.host.toRegistration
 import arcs.core.testutil.handles.dispatchFetchAll
 import arcs.core.testutil.handles.dispatchStore
 import arcs.showcase.ShowcaseEnvironment
+import arcs.showcase.ShowcaseEnvironmentRemoteStorage
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -32,7 +33,7 @@ class DataWriter : AbstractDataWriter()
 class ExpressionShowcaseTest {
 
   @get:Rule
-  val env = ShowcaseEnvironment(
+  val env = ShowcaseEnvironmentRemoteStorage(
     ::DataWriter.toRegistration(),
     ::StatsChecker.toRegistration(),
     ::EvaluatorParticle.toRegistration()


### PR DESCRIPTION
See ExpressionShowCaseTest using ShowcaseEnvironmentRemoteStorage

This sets up RemoteStorageEndpointManager (the client) and RemoteStorageEndpointManagerServer (the server) over a pair of channels.

My idea is that we have phones over WebRTC generate a random number say, between 1 and 2^32, and exchange. The higher number wins and starts the RemoteStorageEndpointManagerServer sending data over Channels which reads/writes into the PeerConnection. This phone uses a regular DirectStorageEndpointManager or AndroidStorageServiceEndpointManager to bootstrap it's ArcHosts.

The phone with the lower number sets up a RemoteStorageEndpointManager that reads/writes from Channels over PeerConnection. 

This phone bootstraps its ArcHosts by giving it the RemoteStorageEndpointManager instance. 

The ShowcaseEnvironmentRemoteStorage demos this, by constructing a ShowcaseHost around the RemoteStorageEndpointManager and constructing a RemoteStorageEndpointManagerServer around a DirectStorageEndpointManager as its backing mechanism.
